### PR TITLE
Fixes findOntology()

### DIFF
--- a/src/main/java/br/ufsc/inf/lapesd/alignator/core/ontology/manager/OntologyManager.java
+++ b/src/main/java/br/ufsc/inf/lapesd/alignator/core/ontology/manager/OntologyManager.java
@@ -178,7 +178,10 @@ public class OntologyManager {
         for (Entry<String, Model> e : mapPrefixOntologyWithIndividuals.entrySet()) {
             for (RDFNode type : types) {
                 Resource ontClass = e.getValue().createResource(type.asResource().getURI());
-                if(ontClass != null)
+                StmtIterator it = ontClass.listProperties();
+                boolean hasSubject = it.hasNext();
+                it.close();
+                if(hasSubject)
                     return new OntologyMatch(e.getKey(), ontClass);
             }
         }


### PR DESCRIPTION
findOntology was always selecting the first ontology. Now it selects the first ontology that defines some property of some type of the resource.