### PR TITLE
Keep a single ExecutorService and shutdown it.

### DIFF
--- a/src/main/java/br/ufsc/inf/lapesd/alignator/core/ontology/matcher/AromaOntologyMatcher.java
+++ b/src/main/java/br/ufsc/inf/lapesd/alignator/core/ontology/matcher/AromaOntologyMatcher.java
@@ -24,6 +24,7 @@ import fr.inrialpes.exmo.align.impl.ObjectAlignment;
 import fr.inrialpes.exmo.aroma.AROMA;
 
 import javax.annotation.Nonnull;
+import javax.annotation.PreDestroy;
 
 import static br.ufsc.inf.lapesd.alignator.core.ontology.matcher.MatcherUtils.incorporateAlignments;
 import static br.ufsc.inf.lapesd.alignator.core.ontology.matcher.MatcherUtils.serialize;
@@ -51,6 +52,12 @@ public class AromaOntologyMatcher implements OntologyMatcher {
         }
 
         return allAlignments;
+    }
+
+    @PreDestroy
+    @Override
+    public void close() {
+        /* nothing */
     }
 
     private List<Alignment> align(File pathToOntology1, File pathToOntology2) {

--- a/src/main/java/br/ufsc/inf/lapesd/alignator/core/ontology/matcher/OntologyMatcher.java
+++ b/src/main/java/br/ufsc/inf/lapesd/alignator/core/ontology/matcher/OntologyMatcher.java
@@ -6,11 +6,15 @@ import org.apache.jena.rdf.model.Model;
 import org.springframework.stereotype.Component;
 
 import javax.annotation.Nonnull;
+import javax.annotation.PreDestroy;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 
 @Component
-public interface OntologyMatcher {
+public interface OntologyMatcher extends AutoCloseable {
     List<Alignment> align(@Nonnull Model mergedModel, @Nonnull Collection<Model> ontologies) throws Exception;
+    @PreDestroy
+    @Override
+    void close();
 }


### PR DESCRIPTION
Instead of creating a new ExecutorService (and leaking 1000s of threads) on each Paris call, create a single ExecutorService with unbounded number of threads and shutdown it when the OntologyMatcher is destroyed.

Added a @PreDestroy close() method on OntologyMatcher.